### PR TITLE
Add isAuthenticated flag to AuthContext

### DIFF
--- a/project/src/context/AuthContext.tsx
+++ b/project/src/context/AuthContext.tsx
@@ -15,6 +15,7 @@ interface AuthContextType {
   user: User | null;
   profile: Profile | null;
   session: Session | null;
+  isAuthenticated: boolean;
   isAdmin: boolean;
   loading: boolean;
 
@@ -51,6 +52,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
+  const isAuthenticated = !!user;
 
   /* ---------- supabase not configured ---------- */
   if (!supabase) {
@@ -60,6 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           user: null,
           profile: null,
           session: null,
+          isAuthenticated: false,
           isAdmin: false,
           loading: false,
           signIn: async () =>
@@ -193,6 +196,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         user,
         profile,
         session,
+        isAuthenticated,
         isAdmin: profile?.role === 'admin',
         loading,
         signInWithEmail,


### PR DESCRIPTION
## Summary
- extend `AuthContext` type with `isAuthenticated`
- compute `isAuthenticated` in the provider
- expose the flag in the provider value

## Testing
- `npm --prefix project run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881636d2c148329ab4b1e35c4f4a06c